### PR TITLE
fix: blacklist node_modules if use npm link

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,10 @@ function gulpRequireTasks (options) {
 
   // Recursively visiting all modules in the specified directory
   // and registering Gulp tasks.
+  blacklist = /node_modules/,
   requireDirectory(module, options.path, {
-    visit: moduleVisitor
+        visit: moduleVisitor,
+        exclude: blacklist
   });
 
   /**


### PR DESCRIPTION
# Description

All is ok with gulp-require-tasks with my project, but if I use npm link for my projects I have error with requireDirectory who call node_modules and create many error


Exemple:

I have module name: css-client with gulpfile.js.

css-client/
  - gulpfile.js
  - src/*.js 


I have project name: use-css-client with another gulpfile.js

use-css-client/
   - gulpfile.js
   - src/*.js
   - node_modules/css-client/gulpfile.js


My gulpfile.js 

`` js
gulpRequireTasks({
    path: __dirname + '/node_modules/css-client/',
});
``

All is ok in this case.

But if I use npm link with css-client I have this tree 

use-css-client/
   - gulpfile.js
   - src/*.js
   - node_modules/css-client/gulpfile.js
   - node_modules/css-client/node_modules

And when 

`` js
 requireDirectory(module, options.path, {
        visit: moduleVisitor,
  });
``

It try to load node_modules, so I exclude folder.






